### PR TITLE
Update bastille.conf.sample

### DIFF
--- a/usr/local/etc/bastille/bastille.conf.sample
+++ b/usr/local/etc/bastille/bastille.conf.sample
@@ -41,7 +41,7 @@ bastille_url_midnightbsd="https://www.midnightbsd.org/ftp/MidnightBSD/releases/"
 ## ZFS options
 bastille_zfs_enable=""                                                ## default: ""
 bastille_zfs_zpool=""                                                 ## default: ""
-bastille_zfs_prefix="${bastille_zfs_zpool}/bastille"                  ## default: "${bastille_zfs_zpool}/bastille"
+bastille_zfs_prefix="bastille"                                        ## default: "bastille"
 bastille_zfs_options="-o compress=lz4 -o atime=off"                   ## default: "-o compress=lz4 -o atime=off"
 
 ## Export/Import options


### PR DESCRIPTION
removed $bastille_zfs_zpool from bastille zfs_prefix as it's called as $bastille_zfs_zpool/$bastille_zfs_prefix in bootstrap.sh, clone.sh, create.sh, destroy.sh, export.sh, import.sh, rename.sh, zfs.sh and causes duplicate zpool name which leads to errors.